### PR TITLE
Fix static ESP8266 AP password

### DIFF
--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -4,3 +4,5 @@
 - The workflow compiles the existing `bp_ckecker8266` Arduino sketch for a NodeMCU-style ESP8266 board using `arduino/compile-sketches`.
 - The CI installs the ESP8266 Boards Manager package, the local `lib/` headers, and the ArduinoJson dependency; it does not require secrets, hardware, deployment steps, or device upload credentials.
 - The sketch now includes local project headers through the Arduino library include path so CI can compile from the sketch directory.
+- Removed the static first-boot AP password and now generate a random default that is saved to EEPROM when no saved AP password exists.
+- Documented the generated first-boot AP password flow and the expected post-setup AP password change.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ ESP8266-based WiFi blood pressure monitor bridge. Reads data from OMRON blood pr
 
 1. Flash firmware via Arduino IDE or PlatformIO
 2. Connect to `ESP8266_BP_checker` AP
-3. Configure WiFi via web interface
+3. Use the generated AP password printed in the serial monitor on first boot. The firmware saves it to EEPROM for later boots.
+4. Configure WiFi via web interface
+5. Change the AP password from the web interface after initial setup
 
 ## License
 

--- a/bp_ckecker8266/bp_ckecker8266.ino
+++ b/bp_ckecker8266/bp_ckecker8266.ino
@@ -16,8 +16,7 @@
 
 // AP模式設定
 const char* ap_ssid = "ESP8266_BP_checker";
-const char* default_ap_password = "12345678"; // 預設密碼（首次使用）
-String ap_password_str = "12345678"; // 可從 EEPROM 載入的 AP 密碼
+String ap_password_str = ""; // 啟動時產生或從 EEPROM 載入的 AP 密碼
 const char* hostname = "bp_checker"; // mDNS主機名
 
 // WiFi設定
@@ -49,6 +48,15 @@ bool apMode = false;
 #define BP_MODEL_ADDR 128
 #define AP_PWD_ADDR 192   // AP密碼在EEPROM中的位置
 #define EEPROM_SIZE 4096  // 增加EEPROM大小以容納更多記錄
+
+String generateDefaultApPassword() {
+  const char alphabet[] = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+  String password = "bp";
+  for (int i = 0; i < 10; i++) {
+    password += alphabet[ESP.random() % (sizeof(alphabet) - 1)];
+  }
+  return password;
+}
 
 // 從EEPROM讀取字串
 String readStringFromEEPROM(int startAddr) {
@@ -285,6 +293,10 @@ void setup() {
   String saved_ap_pwd = readStringFromEEPROM(AP_PWD_ADDR);
   if (saved_ap_pwd.length() >= 8) {  // WiFi 密碼最少 8 碼
     ap_password_str = saved_ap_pwd;
+  } else {
+    ap_password_str = generateDefaultApPassword();
+    writeStringToEEPROM(AP_PWD_ADDR, ap_password_str);
+    Serial.println("已產生新的 AP 密碼並儲存至 EEPROM");
   }
   Serial.println("AP密碼: " + ap_password_str);
   


### PR DESCRIPTION
## Summary
- remove the static first-boot AP password from the sketch
- generate and persist a random AP password when EEPROM has no saved password
- document the first-boot serial password flow and post-setup password change

## Verification
- git diff --check
- rg -n "12345678|default_ap_password|ESP.getChipId|chip ID|chipId|bp[A-F0-9]" . (no matches)

Notes: I did not run a local Arduino compile because arduino-cli is not installed in this workspace; the repo CI should compile the sketch on the PR.